### PR TITLE
SHA256 support changes for DotNet: 

### DIFF
--- a/CyberSource.sln
+++ b/CyberSource.sln
@@ -51,8 +51,8 @@ Global
 		{6EC4A1FB-44CE-4326-92A5-88A1ECC615BD}.Debug_without_setup|x86.Build.0 = Debug|x86
 		{6EC4A1FB-44CE-4326-92A5-88A1ECC615BD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{6EC4A1FB-44CE-4326-92A5-88A1ECC615BD}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{6EC4A1FB-44CE-4326-92A5-88A1ECC615BD}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
-		{6EC4A1FB-44CE-4326-92A5-88A1ECC615BD}.Debug|Mixed Platforms.Build.0 = Debug|x86
+		{6EC4A1FB-44CE-4326-92A5-88A1ECC615BD}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{6EC4A1FB-44CE-4326-92A5-88A1ECC615BD}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
 		{6EC4A1FB-44CE-4326-92A5-88A1ECC615BD}.Debug|Win32.ActiveCfg = Debug|x86
 		{6EC4A1FB-44CE-4326-92A5-88A1ECC615BD}.Debug|Win32.Build.0 = Debug|x86
 		{6EC4A1FB-44CE-4326-92A5-88A1ECC615BD}.Debug|x86.ActiveCfg = Debug|x86
@@ -83,8 +83,8 @@ Global
 		{F47D95C8-8CB6-495C-B2EB-09DAEC073355}.Debug_without_setup|x86.Build.0 = Debug|x86
 		{F47D95C8-8CB6-495C-B2EB-09DAEC073355}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{F47D95C8-8CB6-495C-B2EB-09DAEC073355}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{F47D95C8-8CB6-495C-B2EB-09DAEC073355}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
-		{F47D95C8-8CB6-495C-B2EB-09DAEC073355}.Debug|Mixed Platforms.Build.0 = Debug|x86
+		{F47D95C8-8CB6-495C-B2EB-09DAEC073355}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{F47D95C8-8CB6-495C-B2EB-09DAEC073355}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
 		{F47D95C8-8CB6-495C-B2EB-09DAEC073355}.Debug|Win32.ActiveCfg = Debug|x86
 		{F47D95C8-8CB6-495C-B2EB-09DAEC073355}.Debug|Win32.Build.0 = Debug|x86
 		{F47D95C8-8CB6-495C-B2EB-09DAEC073355}.Debug|x86.ActiveCfg = Debug|x86


### PR DESCRIPTION
**SHA256 support changes for DotNet:**
1. Changes to fetch proper certificate from .p12 file 
2. Changes to sign request with SHA2
