### PR TITLE
Don't use DefaultWebProxy in SoapClient

### DIFF
--- a/CyberSource/Client/BaseClient.cs
+++ b/CyberSource/Client/BaseClient.cs
@@ -38,7 +38,26 @@ namespace CyberSource.Clients
         private const string PROXY_URL = "proxyURL";
         private const string PROXY_USER = "proxyUser";
         private const string PROXY_PASSWORD = "proxyPassword";
-        private const string BASIC_AUTH = "Basic";
+        protected const string BASIC_AUTH = "Basic";
+
+        protected static Uri ProxyUri
+        {
+            get
+            {
+                var proxyURL = AppSettings.GetSetting(null, PROXY_URL);
+                return !string.IsNullOrEmpty(proxyURL) ? new Uri(proxyURL) : null;
+            }
+        }
+
+        protected static string ProxyUser
+        {
+            get { return AppSettings.GetSetting(null, PROXY_USER); }
+        }
+
+        protected static string ProxyPassword
+        {
+            get { return AppSettings.GetSetting(null, PROXY_PASSWORD); }
+        }
 
 		static BaseClient()
 		{
@@ -49,25 +68,18 @@ namespace CyberSource.Clients
         {
             // if a proxyURL is specified in the configuration file,
             // create a WebProxy object for later use.
-            string proxyURL = AppSettings.GetSetting(null, PROXY_URL);
-            if (proxyURL != null)
+            if (ProxyUri != null)
             {
-                mProxy = new WebProxy(proxyURL);
+                mProxy = new WebProxy(ProxyUri);
 
                 // if a proxyUser is specified in the configuration file,
                 // set up the proxy object's Credentials.
-                string proxyUser
-                    = AppSettings.GetSetting(null, PROXY_USER);
-                if (proxyUser != null)
+                if (ProxyUser != null)
                 {
-                    string proxyPassword
-                        = AppSettings.GetSetting(null, PROXY_PASSWORD);
-
-                    NetworkCredential credential
-                        = new NetworkCredential(proxyUser, proxyPassword);
+                    NetworkCredential credential = new NetworkCredential(ProxyUser, ProxyPassword);
 
                     CredentialCache cache = new CredentialCache();
-                    cache.Add(new Uri(proxyURL), BASIC_AUTH, credential);
+                    cache.Add(ProxyUri, BASIC_AUTH, credential);
                     mProxy.Credentials = cache;
                 }
             }
@@ -311,8 +323,7 @@ namespace CyberSource.Clients
 
             //Use custom encoder to strip unsigned timestamp in response
             CustomTextMessageBindingElement textBindingElement = new CustomTextMessageBindingElement();
-
-
+            
             //Setup https transport 
             HttpsTransportBindingElement httpsTransport = new HttpsTransportBindingElement();
             httpsTransport.RequireClientCertificate = true;
@@ -323,8 +334,8 @@ namespace CyberSource.Clients
             //Setup Proxy if needed
             if (mProxy != null)
             {
-                WebRequest.DefaultWebProxy = mProxy;
-                httpsTransport.UseDefaultWebProxy = true;
+                httpsTransport.ProxyAuthenticationScheme = AuthenticationSchemes.Basic;
+                httpsTransport.ProxyAddress = mProxy.Address;
             }
 
 

--- a/CyberSource/Client/SoapClient.cs
+++ b/CyberSource/Client/SoapClient.cs
@@ -1,9 +1,11 @@
 using System;
+using System.Configuration;
 using System.IO;
 using System.Net;
 using System.Security.Cryptography.X509Certificates;
 using System.ServiceModel;
 using System.ServiceModel.Channels;
+using System.ServiceModel.Security;
 using CyberSource.Base;
 using CyberSource.Clients.SoapServiceReference;
 
@@ -68,8 +70,15 @@ namespace CyberSource.Clients
                 EndpointAddress endpointAddress = new EndpointAddress( new Uri(config.EffectiveServerURL), EndpointIdentity.CreateDnsIdentity(config.EffectivePassword), headers );
                 
                 //Get instance of service
-                using( proc = new TransactionProcessorClient(currentBinding, endpointAddress)){
-                
+                using( proc = new TransactionProcessorClient(currentBinding, endpointAddress)) {
+
+                    // Set proxy Basic auth credentials
+                    if (ProxyUser != null)
+                    {
+                        proc.ClientCredentials.UserName.Password = ProxyPassword;
+                        proc.ClientCredentials.UserName.UserName = ProxyUser;
+                    }
+
                     //Set protection level to sign only
                     proc.Endpoint.Contract.ProtectionLevel = System.Net.Security.ProtectionLevel.Sign;
 


### PR DESCRIPTION
I want to use the SoapClient with a proxy server that proxies requests just for Cybersource. We noticed in our staging environment that when using a proxy with the CS SDK, all web requests were sent through the proxy because of UseDefaultWebProxy = true, which is not desirable for us (for example we send requests to our hosting provider's API which we would prefer not to be proxied). This appears to be inconsistent with the XmlClient's behaviour.

To get around this I've set UseDefaultWebProxy = false, however this caused authentication errors on the proxy. I observed that it is possible to add credentials to TransactionProcessorClient.ClientCredentials and they are used when connecting to the proxy server.

This behaviour was observed by creating a new WebRequest in the SoapSample class and watching the proxies access log (squid3). After applying these changes, the extra WebRequest was not shown in the access logs.

I'm not a WCF guy so any feedback on this change would be greatly appreciated!
