### PR TITLE
SoapClient.cs - Add flag for key storage location

### DIFF
--- a/CyberSource/Client/SoapClient.cs
+++ b/CyberSource/Client/SoapClient.cs
@@ -80,13 +80,13 @@ namespace CyberSource.Clients
               
                     //add certificate credentials
                     string keyFilePath = Path.Combine(config.KeysDirectory,config.EffectiveKeyFilename);
-                    proc.ClientCredentials.ClientCertificate.Certificate = new X509Certificate2(keyFilePath,config.EffectivePassword, X509KeyStorageFlags.Exportable | X509KeyStorageFlags.PersistKeySet);
+                    proc.ClientCredentials.ClientCertificate.Certificate = new X509Certificate2(keyFilePath,config.EffectivePassword, X509KeyStorageFlags.Exportable | X509KeyStorageFlags.PersistKeySet | X509KeyStorageFlags.MachineKeySet);
 
                     proc.ClientCredentials.ServiceCertificate.Authentication.CertificateValidationMode = System.ServiceModel.Security.X509CertificateValidationMode.None;
 
                     // Changes for SHA2 certificates support
                     X509Certificate2Collection collection = new X509Certificate2Collection();
-                    collection.Import(keyFilePath, config.EffectivePassword, X509KeyStorageFlags.Exportable | X509KeyStorageFlags.PersistKeySet);
+                    collection.Import(keyFilePath, config.EffectivePassword, X509KeyStorageFlags.Exportable | X509KeyStorageFlags.PersistKeySet | X509KeyStorageFlags.MachineKeySet);
 
                     foreach (X509Certificate2 cert1 in collection)
                     {


### PR DESCRIPTION
For our server setup, each grouping of webservices runs in its own AppPool. In our setup the 'Identity' of the 'Process Model' for the App Pool settings is not one of the standard built-in accounts (like NETWORK SERVICE). We use an AD account that we created for tracking purposes. Because the CyberSource certs are typically stored in the 'Current User' store and not the 'Local Computer' store all calls to CyberSource fail for "System.Security.Cryptography.CryptographicException: An internal error occurred." The App Pool identity needs access to the keys, so we add the extra flag of 'X509KeyStorageFlags.MachineKeySet' and all is well!
