### PR TITLE
machinekeyset flag added to client certificate

### DIFF
--- a/CyberSource/Client/NVPClient.cs
+++ b/CyberSource/Client/NVPClient.cs
@@ -80,7 +80,7 @@ namespace CyberSource.Clients
 
 
                     string keyFilePath = Path.Combine(config.KeysDirectory, config.EffectiveKeyFilename);
-                    proc.ClientCredentials.ClientCertificate.Certificate = new X509Certificate2(keyFilePath, config.EffectivePassword, X509KeyStorageFlags.Exportable | X509KeyStorageFlags.PersistKeySet);
+                    proc.ClientCredentials.ClientCertificate.Certificate = new X509Certificate2(keyFilePath, config.EffectivePassword, X509KeyStorageFlags.MachineKeySet | X509KeyStorageFlags.Exportable | X509KeyStorageFlags.PersistKeySet);
 
                     proc.ClientCredentials.ServiceCertificate.Authentication.CertificateValidationMode = System.ServiceModel.Security.X509CertificateValidationMode.None;
 

--- a/CyberSource/Client/SoapClient.cs
+++ b/CyberSource/Client/SoapClient.cs
@@ -80,7 +80,7 @@ namespace CyberSource.Clients
               
                     //add certificate credentials
                     string keyFilePath = Path.Combine(config.KeysDirectory,config.EffectiveKeyFilename);
-                    proc.ClientCredentials.ClientCertificate.Certificate = new X509Certificate2(keyFilePath,config.EffectivePassword, X509KeyStorageFlags.Exportable | X509KeyStorageFlags.PersistKeySet);
+                    proc.ClientCredentials.ClientCertificate.Certificate = new X509Certificate2(keyFilePath,config.EffectivePassword, X509KeyStorageFlags.MachineKeySet | X509KeyStorageFlags.Exportable | X509KeyStorageFlags.PersistKeySet);
 
                     proc.ClientCredentials.ServiceCertificate.Authentication.CertificateValidationMode = System.ServiceModel.Security.X509CertificateValidationMode.None;
 

--- a/CyberSource/Client/XmlClient.cs
+++ b/CyberSource/Client/XmlClient.cs
@@ -90,7 +90,7 @@ namespace CyberSource.Clients
                 X509Certificate2 cybsCert = null;
 
                 X509Certificate2Collection collection = new X509Certificate2Collection();
-                collection.Import(keyFilePath, config.EffectivePassword, X509KeyStorageFlags.Exportable | X509KeyStorageFlags.PersistKeySet);
+                collection.Import(keyFilePath, config.EffectivePassword, X509KeyStorageFlags.MachineKeySet | X509KeyStorageFlags.Exportable | X509KeyStorageFlags.PersistKeySet);
 
                 foreach (X509Certificate2 cert1 in collection)
                 {


### PR DESCRIPTION
MachineKeySet flag was added to ClientCertificate to fix the issue faced while running transactions on Azure Cloud Service.