### PR TITLE
Allow to load certificate from memory

### DIFF
--- a/CyberSource/Client/BaseClient.cs
+++ b/CyberSource/Client/BaseClient.cs
@@ -1,6 +1,7 @@
 using CyberSource.Base;
 using System;
 using System.Net;
+using System.Security.Cryptography.X509Certificates;
 using System.ServiceModel;
 using System.Xml.Serialization;
 using System.ServiceModel.Channels;
@@ -358,6 +359,39 @@ namespace CyberSource.Clients
             currentBinding.Elements.Add(textBindingElement);
             currentBinding.Elements.Add(httpsTransport);
             return currentBinding;
+        }
+
+        /// <summary>
+        /// Creates a new instance of X509Certificate2
+        /// </summary>
+        /// <param name="config">
+        /// Configuration object containing the key content or file path
+        /// </param>
+        /// <returns>New instance of X509Certificate2</returns>
+        protected static X509Certificate2 GetCertificate(Configuration config)
+        {
+            var flags = X509KeyStorageFlags.Exportable | X509KeyStorageFlags.PersistKeySet;
+            return config.Key != null
+                ? new X509Certificate2(config.Key, config.EffectivePassword, flags)
+                : new X509Certificate2(config.EffectiveKeyFilePath, config.EffectivePassword, flags);
+        }
+
+        /// <summary>
+        /// Creates a certificate collection with an imported certificate
+        /// </summary>
+        /// <param name="config">
+        /// Configuration object containing the key content or file path
+        /// </param>
+        /// <returns>New instance of X509Certificate2Collection with an imported certificate</returns>
+        protected static X509Certificate2Collection GetCertificateCollection(Configuration config)
+        {
+            var collection = new X509Certificate2Collection();
+            var flags = X509KeyStorageFlags.Exportable | X509KeyStorageFlags.PersistKeySet;
+            if (config.Key != null)
+                collection.Import(config.Key, config.EffectivePassword, flags);
+            else
+                collection.Import(config.EffectiveKeyFilePath, config.EffectivePassword, flags);
+            return collection;
         }
     }
 }

--- a/CyberSource/Client/Configuration.cs
+++ b/CyberSource/Client/Configuration.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 
 namespace CyberSource.Clients
 {
@@ -62,6 +63,7 @@ namespace CyberSource.Clients
         private string logDirectory = null;
         private string serverURL = null;
         private string keyFilename = null;
+        private byte[] key = null;
         private string password = null;
         private string logFilename = null;
         private int logMaximumSize = -1;
@@ -159,6 +161,15 @@ namespace CyberSource.Clients
         {
             get { return serverURL; }
             set { serverURL = value; }
+        }
+
+        /// <summary>
+        /// This is optional. When set, it reads key from memory rather than from file system
+        /// </summary>
+        public byte[] Key
+        {
+            get { return key; }
+            set { key = value; }
         }
 
         /// <summary>
@@ -377,6 +388,18 @@ namespace CyberSource.Clients
                     keyFilename != null 
                         ? keyFilename 
                         : merchantID + P12_EXTENSION );
+            }
+        }
+
+        /// <summary>
+        /// Return the key file path that will take effect given
+        /// the current state of this Configuration object.
+        /// </summary>
+        internal string EffectiveKeyFilePath
+        {
+            get
+            {
+                return Path.Combine(KeysDirectory, EffectiveKeyFilename);
             }
         }
 

--- a/CyberSource/Client/NVPClient.cs
+++ b/CyberSource/Client/NVPClient.cs
@@ -80,13 +80,12 @@ namespace CyberSource.Clients
 
 
                     string keyFilePath = Path.Combine(config.KeysDirectory, config.EffectiveKeyFilename);
-                    proc.ClientCredentials.ClientCertificate.Certificate = new X509Certificate2(keyFilePath, config.EffectivePassword, X509KeyStorageFlags.Exportable | X509KeyStorageFlags.PersistKeySet);
+                    proc.ClientCredentials.ClientCertificate.Certificate = GetCertificate(config);
 
                     proc.ClientCredentials.ServiceCertificate.Authentication.CertificateValidationMode = System.ServiceModel.Security.X509CertificateValidationMode.None;
 
                     // Changes for SHA2 certificates support
-                    X509Certificate2Collection collection = new X509Certificate2Collection();
-                    collection.Import(keyFilePath, config.EffectivePassword, X509KeyStorageFlags.Exportable | X509KeyStorageFlags.PersistKeySet);
+                    X509Certificate2Collection collection = GetCertificateCollection(config);
 
                     foreach (X509Certificate2 cert1 in collection)
                     {

--- a/CyberSource/Client/SoapClient.cs
+++ b/CyberSource/Client/SoapClient.cs
@@ -79,14 +79,12 @@ namespace CyberSource.Clients
                     currentBinding.SendTimeout = timeOut;
               
                     //add certificate credentials
-                    string keyFilePath = Path.Combine(config.KeysDirectory,config.EffectiveKeyFilename);
-                    proc.ClientCredentials.ClientCertificate.Certificate = new X509Certificate2(keyFilePath,config.EffectivePassword, X509KeyStorageFlags.Exportable | X509KeyStorageFlags.PersistKeySet);
+                    proc.ClientCredentials.ClientCertificate.Certificate = GetCertificate(config);
 
                     proc.ClientCredentials.ServiceCertificate.Authentication.CertificateValidationMode = System.ServiceModel.Security.X509CertificateValidationMode.None;
 
                     // Changes for SHA2 certificates support
-                    X509Certificate2Collection collection = new X509Certificate2Collection();
-                    collection.Import(keyFilePath, config.EffectivePassword, X509KeyStorageFlags.Exportable | X509KeyStorageFlags.PersistKeySet);
+                    X509Certificate2Collection collection = GetCertificateCollection(config);
 
                     foreach (X509Certificate2 cert1 in collection)
                     {

--- a/CyberSource/Client/XmlClient.cs
+++ b/CyberSource/Client/XmlClient.cs
@@ -84,13 +84,11 @@ namespace CyberSource.Clients
                 XmlDocument doc = SoapWrap(request, nspace);
 
                 //Get the X509 cert and sign the SOAP Body    
-                string keyFilePath = Path.Combine(config.KeysDirectory, config.EffectiveKeyFilename);
 
                 X509Certificate2 cert = null;
                 X509Certificate2 cybsCert = null;
 
-                X509Certificate2Collection collection = new X509Certificate2Collection();
-                collection.Import(keyFilePath, config.EffectivePassword, X509KeyStorageFlags.Exportable | X509KeyStorageFlags.PersistKeySet);
+                X509Certificate2Collection collection = GetCertificateCollection(config);
 
                 foreach (X509Certificate2 cert1 in collection)
                 {


### PR DESCRIPTION
Sometimes it's necessary to use different storage for certificates. So, if it's possible to load certificate from memory, I'm not bound to a file system